### PR TITLE
Fix src <-> dst swapped, for masking extended id

### DIFF
--- a/xcpdump.c
+++ b/xcpdump.c
@@ -128,13 +128,13 @@ int main(int argc, char **argv)
                 case 'm':
                         dst = strtoul(optarg, (char **)NULL, 16);
                         if (strlen(optarg) > 7)
-                                src |= CAN_EFF_FLAG;
+                                dst |= CAN_EFF_FLAG;
                         break;
 
                 case 's':
                         src = strtoul(optarg, (char **)NULL, 16);
                         if (strlen(optarg) > 7)
-                                dst |= CAN_EFF_FLAG;
+                                src |= CAN_EFF_FLAG;
                         break;
 
                 case 'd':


### PR DESCRIPTION
Hi,

dst and src was switched, so wrong variable was masked as CAN extended id. Tested with my CAN XCP slave with extended CAN id.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [X My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.




